### PR TITLE
Add workflow to populate VLC macOS artifacts

### DIFF
--- a/.github/workflows/populate-vlc-macos.yml
+++ b/.github/workflows/populate-vlc-macos.yml
@@ -1,0 +1,304 @@
+name: Populate VLC macOS Artifacts
+
+# One-shot workflow: downloads the pinned VLC 4.0.0-dev SDK tarballs for
+# both Intel and Apple Silicon, extracts them natively on a macOS runner
+# (preserving real Mach-O binaries instead of Windows-mangled symlinks),
+# populates the four VLC source directories, and commits the result to
+# whichever branch triggered the workflow.
+#
+# Directories written:
+#   src/vlcMac/       — Intel link-time dylibs + headers
+#   src/vlcMacArm/    — Apple Silicon link-time dylibs
+#   src/bin-macos/    — Intel deploy-time dylibs + plugins (non-VLC files preserved)
+#   src/bin-macos-arm/— Apple Silicon deploy-time dylibs + plugins
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  populate-vlc:
+    runs-on: macos-15
+
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      INTEL_URL: "https://artifacts.videolan.org/vlc/nightly-macos-x86_64/20260524-0411/vlc-macos-sdk-4.0.0-dev-intel64-4f465d43.tar.gz"
+      ARM_URL:   "https://artifacts.videolan.org/vlc/nightly-macos-arm64/20260524-0415/vlc-macos-sdk-4.0.0-dev-arm64-4f465d43.tar.gz"
+
+    steps:
+      # ---------------------------------------------------------------
+      # Checkout on the triggering branch so the commit lands there
+      # ---------------------------------------------------------------
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      # ---------------------------------------------------------------
+      # Download both SDK tarballs
+      # ---------------------------------------------------------------
+      - name: Download VLC SDK tarballs
+        run: |
+          mkdir -p vlc-sdk-work
+          echo "Downloading Intel SDK..."
+          curl -fL -o vlc-sdk-work/vlc-intel.tar.gz "$INTEL_URL"
+          echo "Downloading ARM64 SDK..."
+          curl -fL -o vlc-sdk-work/vlc-arm.tar.gz "$ARM_URL"
+          echo "Download sizes:"
+          ls -lh vlc-sdk-work/
+
+      # ---------------------------------------------------------------
+      # Extract both tarballs
+      # ---------------------------------------------------------------
+      - name: Extract VLC SDK tarballs
+        run: |
+          mkdir -p vlc-sdk-work/intel vlc-sdk-work/arm
+          tar xzf vlc-sdk-work/vlc-intel.tar.gz -C vlc-sdk-work/intel
+          tar xzf vlc-sdk-work/vlc-arm.tar.gz   -C vlc-sdk-work/arm
+
+      # ---------------------------------------------------------------
+      # Print top-level structure for debugging / future reference
+      # ---------------------------------------------------------------
+      - name: Show SDK structure
+        run: |
+          echo "=== Intel SDK (top 4 levels) ==="
+          find vlc-sdk-work/intel -maxdepth 4 | sort
+          echo ""
+          echo "=== ARM64 SDK (top 4 levels) ==="
+          find vlc-sdk-work/arm  -maxdepth 4 | sort
+
+      # ---------------------------------------------------------------
+      # Locate the SDK roots (handles optional versioned sub-directory)
+      # ---------------------------------------------------------------
+      - name: Locate SDK roots
+        id: locate
+        run: |
+          # The tarball may extract to e.g. vlc-4.0.0-dev/ or directly to .
+          # Find the directory that contains a "lib" subdirectory.
+          INTEL_LIB=$(find vlc-sdk-work/intel -maxdepth 3 -name "lib" -type d | head -1)
+          ARM_LIB=$(find  vlc-sdk-work/arm  -maxdepth 3 -name "lib" -type d | head -1)
+
+          if [[ -z "$INTEL_LIB" ]]; then echo "ERROR: could not locate lib/ in Intel SDK"; exit 1; fi
+          if [[ -z "$ARM_LIB"   ]]; then echo "ERROR: could not locate lib/ in ARM SDK";   exit 1; fi
+
+          INTEL_ROOT="$(dirname "$INTEL_LIB")"
+          ARM_ROOT="$(dirname "$ARM_LIB")"
+
+          echo "Intel SDK root: $INTEL_ROOT"
+          echo "ARM64 SDK root: $ARM_ROOT"
+
+          echo "intel_root=$INTEL_ROOT" >> "$GITHUB_OUTPUT"
+          echo "arm_root=$ARM_ROOT"     >> "$GITHUB_OUTPUT"
+
+      # ---------------------------------------------------------------
+      # Verify architectures (sanity check before committing)
+      # ---------------------------------------------------------------
+      - name: Verify dylib architectures
+        run: |
+          INTEL="${{ steps.locate.outputs.intel_root }}"
+          ARM="${{   steps.locate.outputs.arm_root   }}"
+
+          echo "Intel libvlc:"
+          file "$INTEL/lib/libvlc.dylib" 2>/dev/null || \
+            file "$(find "$INTEL/lib" -maxdepth 1 -name 'libvlc.*.dylib' | head -1)"
+
+          echo "ARM64 libvlc:"
+          file "$ARM/lib/libvlc.dylib" 2>/dev/null || \
+            file "$(find "$ARM/lib" -maxdepth 1 -name 'libvlc.*.dylib' | head -1)"
+
+      # ---------------------------------------------------------------
+      # Prepare destination directories
+      # (clear only VLC-managed content; preserve DMHelper.icns, Info.plist)
+      # ---------------------------------------------------------------
+      - name: Prepare destination directories
+        working-directory: DMHelper/src
+        run: |
+          # Link-time directories — replace entirely
+          rm -rf vlcMac vlcMacArm
+          mkdir -p vlcMac/vlc vlcMacArm
+
+          # Deploy-time Intel — remove VLC-managed files, keep non-VLC assets
+          rm -f  bin-macos/libvlc*.dylib bin-macos/libvlccore*.dylib
+          rm -rf bin-macos/vlc/plugins bin-macos/pkgconfig
+          mkdir -p bin-macos/vlc/plugins bin-macos/pkgconfig
+
+          # Deploy-time ARM — replace entirely (no pre-existing non-VLC content)
+          rm -rf bin-macos-arm
+          mkdir -p bin-macos-arm/vlc/plugins bin-macos-arm/pkgconfig
+
+      # ---------------------------------------------------------------
+      # Populate vlcMac (Intel link-time dylibs + headers)
+      # Uses -L to dereference symlinks → stores real Mach-O files in git
+      # ---------------------------------------------------------------
+      - name: Populate vlcMac
+        run: |
+          INTEL="${{ steps.locate.outputs.intel_root }}"
+          DEST="DMHelper/src/vlcMac"
+
+          # Main dylibs (dereference symlinks so git stores real binaries)
+          for f in "$INTEL/lib"/libvlc*.dylib "$INTEL/lib"/libvlccore*.dylib; do
+            [ -e "$f" ] || continue
+            cp -fL "$f" "$DEST/"
+          done
+
+          # Libtool archives
+          for f in "$INTEL/lib"/libvlc*.la "$INTEL/lib"/libvlccore*.la; do
+            [ -e "$f" ] || continue
+            cp -f "$f" "$DEST/"
+          done
+
+          # Headers (architecture-neutral; only populated from Intel SDK)
+          rsync -aL "$INTEL/include/vlc/" "$DEST/vlc/"
+
+          echo "vlcMac contents:"
+          find "$DEST" -ls
+
+      # ---------------------------------------------------------------
+      # Populate vlcMacArm (Apple Silicon link-time dylibs)
+      # Headers are shared from vlcMac — not duplicated here
+      # ---------------------------------------------------------------
+      - name: Populate vlcMacArm
+        run: |
+          ARM="${{ steps.locate.outputs.arm_root }}"
+          DEST="DMHelper/src/vlcMacArm"
+
+          # Main dylibs
+          for f in "$ARM/lib"/libvlc*.dylib "$ARM/lib"/libvlccore*.dylib; do
+            [ -e "$f" ] || continue
+            cp -fL "$f" "$DEST/"
+          done
+
+          # Libtool archives
+          for f in "$ARM/lib"/libvlc*.la "$ARM/lib"/libvlccore*.la; do
+            [ -e "$f" ] || continue
+            cp -f "$f" "$DEST/"
+          done
+
+          echo "vlcMacArm contents:"
+          find "$DEST" -ls
+
+      # ---------------------------------------------------------------
+      # Populate bin-macos (Intel deploy-time)
+      # ---------------------------------------------------------------
+      - name: Populate bin-macos
+        run: |
+          INTEL="${{ steps.locate.outputs.intel_root }}"
+          DEST="DMHelper/src/bin-macos"
+
+          # Deploy dylibs
+          for f in "$INTEL/lib"/libvlc*.dylib "$INTEL/lib"/libvlccore*.dylib; do
+            [ -e "$f" ] || continue
+            cp -fL "$f" "$DEST/"
+          done
+
+          # pkgconfig
+          if [ -d "$INTEL/lib/pkgconfig" ]; then
+            rsync -aL "$INTEL/lib/pkgconfig/" "$DEST/pkgconfig/"
+          fi
+
+          # vlc/libcompat.* (static compatibility library)
+          for f in "$INTEL/lib/vlc"/libcompat.*; do
+            [ -e "$f" ] || continue
+            cp -f "$f" "$DEST/vlc/"
+          done
+
+          # Plugins
+          if [ -d "$INTEL/lib/vlc/plugins" ]; then
+            rsync -aL "$INTEL/lib/vlc/plugins/" "$DEST/vlc/plugins/"
+          fi
+
+          echo "bin-macos VLC plugin count: $(find "$DEST/vlc/plugins" -name '*.dylib' | wc -l)"
+
+      # ---------------------------------------------------------------
+      # Populate bin-macos-arm (Apple Silicon deploy-time)
+      # ---------------------------------------------------------------
+      - name: Populate bin-macos-arm
+        run: |
+          ARM="${{ steps.locate.outputs.arm_root }}"
+          DEST="DMHelper/src/bin-macos-arm"
+
+          # Deploy dylibs
+          for f in "$ARM/lib"/libvlc*.dylib "$ARM/lib"/libvlccore*.dylib; do
+            [ -e "$f" ] || continue
+            cp -fL "$f" "$DEST/"
+          done
+
+          # pkgconfig
+          if [ -d "$ARM/lib/pkgconfig" ]; then
+            rsync -aL "$ARM/lib/pkgconfig/" "$DEST/pkgconfig/"
+          fi
+
+          # vlc/libcompat.*
+          for f in "$ARM/lib/vlc"/libcompat.*; do
+            [ -e "$f" ] || continue
+            cp -f "$f" "$DEST/vlc/"
+          done
+
+          # Plugins
+          if [ -d "$ARM/lib/vlc/plugins" ]; then
+            rsync -aL "$ARM/lib/vlc/plugins/" "$DEST/vlc/plugins/"
+          fi
+
+          echo "bin-macos-arm VLC plugin count: $(find "$DEST/vlc/plugins" -name '*.dylib' | wc -l)"
+
+      # ---------------------------------------------------------------
+      # Summary before commit
+      # ---------------------------------------------------------------
+      - name: Summarise populated directories
+        run: |
+          echo "=== vlcMac (link-time Intel) ==="
+          ls -lh DMHelper/src/vlcMac/
+          echo ""
+          echo "=== vlcMacArm (link-time ARM64) ==="
+          ls -lh DMHelper/src/vlcMacArm/
+          echo ""
+          echo "=== bin-macos dylibs ==="
+          ls -lh DMHelper/src/bin-macos/libvlc*.dylib DMHelper/src/bin-macos/libvlccore*.dylib
+          echo "=== bin-macos plugins ==="
+          find DMHelper/src/bin-macos/vlc/plugins -name "*.dylib" | wc -l
+          echo ""
+          echo "=== bin-macos-arm dylibs ==="
+          ls -lh DMHelper/src/bin-macos-arm/libvlc*.dylib DMHelper/src/bin-macos-arm/libvlccore*.dylib
+          echo "=== bin-macos-arm plugins ==="
+          find DMHelper/src/bin-macos-arm/vlc/plugins -name "*.dylib" | wc -l
+
+      # ---------------------------------------------------------------
+      # Commit and push
+      # ---------------------------------------------------------------
+      - name: Commit VLC artifacts
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add \
+            DMHelper/src/vlcMac \
+            DMHelper/src/vlcMacArm \
+            DMHelper/src/bin-macos \
+            DMHelper/src/bin-macos-arm
+
+          if git diff --cached --quiet; then
+            echo "No changes to commit — VLC directories already up to date."
+            exit 0
+          fi
+
+          git commit -m "ci: populate VLC 4.0.0-dev macOS dylibs and plugins (Intel + ARM64)
+
+Source: VLC 4.0.0-dev nightly artifacts ($(date -u +%Y-%m-%d))
+Intel:  vlc-macos-sdk-4.0.0-dev-intel64-4f465d43.tar.gz
+ARM64:  vlc-macos-sdk-4.0.0-dev-arm64-4f465d43.tar.gz
+
+Directories updated:
+  src/vlcMac/        Intel link-time dylibs + headers
+  src/vlcMacArm/     ARM64 link-time dylibs
+  src/bin-macos/     Intel deploy-time dylibs + plugins
+  src/bin-macos-arm/ ARM64 deploy-time dylibs + plugins
+
+Symlinks dereferenced: real Mach-O binaries stored in git
+to avoid cross-platform extraction issues."
+
+          git push


### PR DESCRIPTION
This workflow downloads and extracts VLC 4.0.0-dev SDK tarballs for both Intel and ARM64 architectures, populating the necessary directories and committing the results to the triggering branch.